### PR TITLE
fix: remove duplicate scrollbars

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -46,7 +46,6 @@
 	html,
 	body {
 		height: 100%;
-		overflow: scroll;
 	}
 
 	body {


### PR DESCRIPTION
Remove `overflow: scroll;` because it was causing duplicate scrollbars:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7c6f88e6-19f9-4287-9945-7b86f8903e2e" />

Tested in Chrome